### PR TITLE
Reuse provider instance within session

### DIFF
--- a/aiodine/providers.py
+++ b/aiodine/providers.py
@@ -123,6 +123,9 @@ class SessionProvider(Provider):
         self._generator: Optional[AsyncGenerator] = None
 
     async def enter_session(self):
+        if self._instance is not None:
+            return
+
         value = self.func()
 
         if inspect.isawaitable(value):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -37,3 +37,22 @@ async def test_session_provider_destroyed_on_exit(store: Store):
 
     # Instance was reset.
     assert await consumer() == ["resource", "other"]
+
+
+async def test_reuse_session_provider_within_session(store):
+    @store.provider(scope="session")
+    async def bar(foo):
+        return foo
+
+    @store.provider(scope="session")
+    async def foo():
+        return object()
+
+    @store.consumer
+    def consumer(foo, bar):
+        return foo, bar
+
+    store.freeze()
+    async with store.session():
+        foo, bar = await consumer()
+        assert foo is bar


### PR DESCRIPTION
Hi. We've found bug in session providers.
Please check out test. If I define `foo` before `bar` it works as expected.
If `bar` before `foo` then `foo` provider is called twice.